### PR TITLE
Dotnet 8 Support and Removal of Dotnet 6 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,6 @@ using MauiShakeDetector;
 
 Maui Shake Detector is Licensed Under [MIT License](https://github.com/AathifMahir/MauiShakeDetector/blob/master/LICENSE.txt).
 
-# Wanna Help
+# Contribute
 
-Want to Contribute this project, Feel free to Create an Issue or Else Want to Contribute to the Project on Resources, Feel Free to Donate Me Via Below Url or You just want use Package, Feel Free to Do So, No Worries!!!
-
-<a href="https://www.buymeacoffee.com/aathifmahir"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a coffee&emoji=&slug=aathifmahir&button_colour=6b4fdc&font_colour=ffffff&font_family=Lato&outline_colour=ffffff&coffee_colour=FFDD00" /></a>
+If you wish to contribute to this project, please don't hesitate to create an issue or request. Your input and feedback are highly appreciated. Additionally, if you're interested in supporting the project by providing resources or [**becoming a sponsor**](https://github.com/sponsors/AathifMahir), your contributions would be welcomed and instrumental in its continued development and success. Thank you for your interest in contributing to this endeavor.

--- a/sample/MauiShakeDetectorSample/MauiShakeDetectorSample.csproj
+++ b/sample/MauiShakeDetectorSample/MauiShakeDetectorSample.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst;net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0;net7.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
 		<OutputType>Exe</OutputType>
@@ -29,6 +29,11 @@
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 	</PropertyGroup>
+
+	<ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+	</ItemGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)'=='net7.0-ios'">
 	  <CodesignKey>Apple Development: Created via API (VZXRD9YS8B)</CodesignKey>

--- a/src/MauiShakeDetector.UnitTest/MauiShakeDetector.UnitTest.csproj
+++ b/src/MauiShakeDetector.UnitTest/MauiShakeDetector.UnitTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net8.0;net7.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/MauiShakeDetector/IShakeDetector.cs
+++ b/src/MauiShakeDetector/IShakeDetector.cs
@@ -67,12 +67,10 @@ public interface IShakeDetector
     /// </summary>
 #nullable enable
     event EventHandler<ShakeDetectedEventArgs>? ShakeDetected;
-#nullable disable
 
     /// <summary>
     /// Shake stopped event for detecting whether shake detector is stopped when Auto Stop is more than 0
     /// </summary>
-#nullable enable
     event EventHandler? ShakeStopped;
 #nullable disable
     /// <summary>

--- a/src/MauiShakeDetector/MauiShakeDetector.csproj
+++ b/src/MauiShakeDetector/MauiShakeDetector.csproj
@@ -1,23 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst;net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0;net6.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0;net7.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
 
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' And $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 'net7.0'">11.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' And $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 'net7.0'">13.1</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' And $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 'net6.0'">14.2</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' And $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) == 'net6.0'">14.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 	</PropertyGroup>
+
+	<ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+	</ItemGroup>
 
 	<PropertyGroup>
 		<GitInfoReportImportance>high</GitInfoReportImportance>

--- a/src/MauiShakeDetector/MauiShakeDetector.csproj
+++ b/src/MauiShakeDetector/MauiShakeDetector.csproj
@@ -41,9 +41,9 @@
 		<Description>Maui Shake Detector Shake Event Detector Library with Lots of Customization like GForce Tuning, Shake Intervals and Haptics for Shake Events</Description>
 		<PackageIcon>icon.png</PackageIcon>
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
-		<AssemblyVersion>1.0.0.0</AssemblyVersion>
-		<AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
-		<Version>1.0.0</Version>
+		<AssemblyVersion>2.0.0.0</AssemblyVersion>
+		<AssemblyFileVersion>2.0.0.0</AssemblyFileVersion>
+		<Version>2.0.0</Version>
 		<PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<PackageTags>Maui,Shake,ShakeDetector,MauiShake,Accelerometer,Vibration</PackageTags>

--- a/src/MauiShakeDetector/ReleaseNotes.txt
+++ b/src/MauiShakeDetector/ReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿v1.0.0
+﻿v2.0.0
+• Dotnet 8 Support
+
+Breaking Changes
+- Removal of Dotnet 6 Support
+
+v1.0.0
 • Added Shake Stopped Event and Command for Auto Stop Enabled Scenerios
 
 v0.4.0

--- a/src/MauiShakeDetector/ShakeDetectorDefault.cs
+++ b/src/MauiShakeDetector/ShakeDetectorDefault.cs
@@ -30,11 +30,11 @@ internal sealed class ShakeDetectorDefault : IShakeDetector
 
     // Event & Commands
 
-    public event EventHandler<ShakeDetectedEventArgs> ShakeDetected;
-    public event EventHandler ShakeStopped;
+    public event EventHandler<ShakeDetectedEventArgs>? ShakeDetected;
+    public event EventHandler? ShakeStopped;
 
-    public ICommand ShakeDetectedCommand { get; set; }
-    public ICommand ShakeStoppedCommand { get; set; }
+    public ICommand ShakeDetectedCommand { get; set; } = default!;
+    public ICommand ShakeStoppedCommand { get; set; } = default!;
 
     public void StartListening(SensorSpeed sensorSpeed = SensorSpeed.Default)
     {
@@ -47,7 +47,7 @@ internal sealed class ShakeDetectorDefault : IShakeDetector
         Accelerometer.Default.ReadingChanged += Accelerometer_ReadingChanged;
     }
 
-    void Accelerometer_ReadingChanged(object sender, AccelerometerChangedEventArgs e)
+    void Accelerometer_ReadingChanged(object? sender, AccelerometerChangedEventArgs e)
     {
         float y = e.Reading.Acceleration.Y;
         float x = e.Reading.Acceleration.X;


### PR DESCRIPTION
This PR adds support for Dotnet 8 and also removes the support of Dotnet 6 since it's out of Maui Support Cycle